### PR TITLE
Add `data` option

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,13 +2,14 @@
   "maxparams": 5,
   "maxdepth": 3,
   "maxstatements": 30,
-  "maxcomplexity": 12,
+  "maxcomplexity": 13,
   "maxlen": 500,
 
   "node": true,
 
   "bitwise": true,
   "eqeqeq": true,
+  "eqnull": true,
   "esnext": true,
   "forin": true,
   "freeze": true,

--- a/src/refrain.js
+++ b/src/refrain.js
@@ -19,7 +19,8 @@ class Refrain {
       buildDir: 'build',
       layoutDir: 'layouts',
       layout: 'default',
-      pipeline: {}
+      pipeline: {},
+      data: {}
     }, options);
   }
 
@@ -96,6 +97,8 @@ class Refrain {
       }
     }
 
+    let pageData = assign(meta || {}, context.page.data || {}, this.options.data || {});
+
     let content = {
       filePath: path.resolve(refrain.options.srcDir, relativePath).replace(/\\/, '/'),
       page: assign({
@@ -103,7 +106,7 @@ class Refrain {
         filePath: path.join(srcDir, src)
       }, context.page, {
         layout: layout,
-        data: assign(meta || {}, context.page.data || {}),
+        data: pageData,
         template: match ? str.substring(match[0].length).trim() : str
       }),
       render: next => {

--- a/src/refrain.js
+++ b/src/refrain.js
@@ -12,6 +12,17 @@ const FRONT_MATTER_REGEX = /^\s*(([^\s\d\w])\2{2,})(?:\x20*([a-z]+))?([\s\S]*?)\
 
 class Refrain {
 
+  /**
+   * @constructor
+   * @param {String} [srcDir='src'] The source directory
+   * @param {String} [dataDir='data'] The data directory
+   * @param {String} [buildDir='build'] The build directory
+   * @param {String} [layoutDir='layouts'] The layout directory
+   * @param {String} [layout='default'] The default layout
+   * @param {Object} [pipeline={}] The dictionary of pipeline tasks
+   * @param {Object} [data={}] The additional data object, this merges into
+   *                           context.page.data object before pipeline processing.
+   */
   constructor(options) {
     this.options = assign({
       srcDir: 'src',

--- a/test/load.js
+++ b/test/load.js
@@ -1,0 +1,40 @@
+/* global it, describe */
+
+var assert = require('power-assert');
+var createRefrain = require('../src/refrain');
+
+
+describe('refrain', () => {
+  'use strict';
+
+  describe('load', () => {
+
+    it('creates the refrain context', () => {
+
+      var refrain = createRefrain({
+        srcDir: 'test/assets'
+      });
+
+      var context = refrain.load('find1.html', null);
+
+      assert(context != null);
+      assert(typeof context === 'object');
+
+    });
+
+    it('merges the refrain.options.data into context.page.data', () => {
+
+      var refrain = createRefrain({
+        srcDir: 'test/assets',
+        data: {foo: 'bar'}
+      });
+
+      var context = refrain.load('find1.html', null);
+
+      assert(context.page.data.foo === 'bar');
+
+    });
+
+  });
+
+});


### PR DESCRIPTION
Hi,

I added `data` option to refrain constructor. This merges into `content.page.data` object before pipeline processing.
This must be covenient if you want to pass specific parameters for a specific grunt-refrain target.

Thanks,
